### PR TITLE
fix: never leave send() promises pending forever

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,24 @@ import {VcmpServer} from "@variocube/vcmp-server";
 const server = new VcmpServer({port: 12345});
 server.on("hello", ({from}) => console.log(`Received a hello from ${from}.`));
 server.onSessionConnected = (session) => {
-    session.send({"@type": "hello", from: "server"});    
+	session.send({"@type": "hello", from: "server"});
 };
 ```
+
+## Send semantics
+
+The promise returned from `send` settles when the peer acknowledges the message — after the peer's
+message handler has completed:
+
+- It **resolves** with the handler's result when the peer sends an ACK.
+- It **rejects** with a `VcmpError` when:
+  - the peer's handler fails (NAK, carrying the peer's `ProblemDetail`),
+  - the underlying WebSocket is not open at the time of sending (status 503, "Session not open"),
+  - the session closes before the ACK arrives (status 503, "Session closed"), or
+  - the acknowledgement does not arrive within the ack timeout (status 504, "Acknowledgement timeout").
+
+A `send` never stays pending indefinitely. The ack timeout defaults to 30 seconds and can be
+configured — or disabled with a value of 0 — via the `ackTimeout` option of `VcmpClient` and
+`VcmpServer`. Note that a rejection other than a NAK does not imply the peer ignored the message:
+an ACK lost to a connection loss still means the handler ran. Use an idempotent retry if the
+operation must be applied exactly once.

--- a/README.md
+++ b/README.md
@@ -68,8 +68,12 @@ where a bound is needed. The same policy applies in the Java implementation (vcm
 A send on an open session whose peer never acknowledges stays pending until the session closes.
 A dead connection is detected by the heartbeat and closed — provided the heartbeat is running:
 `VcmpServer` initiates it automatically on every connection (`heartbeatInterval`, default 20 s),
-and both sides then watchdog it. A standalone `VcmpSession` only has this protection once
-`initiateHeartbeat` is called (or the peer initiates).
+and both sides then watchdog it. `VcmpClient` additionally expects the server to initiate a
+heartbeat within `initialHeartbeatTimeout` (default 60 s, a value of 0 or below disables it) of
+the connection opening and closes the session otherwise — so a half-open connection through which
+no heartbeat ever arrives cannot leave sends pending indefinitely. A standalone `VcmpSession` only
+has this protection once `initiateHeartbeat` is called (or the peer initiates and `expectHeartbeat`
+bounds the wait for it).
 
 Note that a `VcmpError` rejection no longer implies the peer answered: 503 describes a local
 transport condition, while a NAK carries the peer's own status. A rejection other than a NAK also

--- a/README.md
+++ b/README.md
@@ -39,9 +39,14 @@ import {VcmpServer} from "@variocube/vcmp-server";
 const server = new VcmpServer({port: 12345});
 server.on("hello", ({from}) => console.log(`Received a hello from ${from}.`));
 server.onSessionConnected = (session) => {
-	session.send({"@type": "hello", from: "server"});
+	session.send({"@type": "hello", from: "server"})
+		.catch(error => console.warn("Could not deliver hello", error));
 };
 ```
+
+Note the `.catch`: `send` returns a promise that can reject (see below). A fire-and-forget call
+site must attach a rejection handler, otherwise a session closing at the wrong moment surfaces as
+an unhandled promise rejection — which terminates a Node process by default.
 
 ## Send semantics
 
@@ -53,10 +58,19 @@ message handler has completed:
   - the peer's handler fails (NAK, carrying the peer's `ProblemDetail`),
   - the underlying WebSocket is not open at the time of sending (status 503, "Session not open"),
   - the session closes before the ACK arrives (status 503, "Session closed"), or
-  - the acknowledgement does not arrive within the ack timeout (status 504, "Acknowledgement timeout").
+  - the optional ack timeout elapses first (status 504, "Acknowledgement timeout").
 
-A `send` never stays pending indefinitely. The ack timeout defaults to 30 seconds and can be
-configured — or disabled with a value of 0 — via the `ackTimeout` option of `VcmpClient` and
-`VcmpServer`. Note that a rejection other than a NAK does not imply the peer ignored the message:
-an ACK lost to a connection loss still means the handler ran. Use an idempotent retry if the
-operation must be applied exactly once.
+The ack timeout is **disabled by default**: how long to wait for a live-but-unresponsive peer is
+the caller's decision. Opt in via the `ackTimeout` option (milliseconds) of `VcmpClient` and
+`VcmpServer` to bound every send of that instance, or race an individual send against your own
+timer. With the timeout disabled, a send on a healthy, open session whose peer never acknowledges
+stays pending until the session closes (a dead connection is detected by the heartbeat and closed).
+
+Note that a `VcmpError` rejection no longer implies the peer answered: 503/504 describe local
+transport conditions, while a NAK carries the peer's own status. A rejection other than a NAK also
+does not imply the peer ignored the message: an ACK lost to a connection loss still means the
+handler ran. Use an idempotent retry if the operation must be applied exactly once.
+
+**Upgrade note (breaking):** sends that previously could stay pending forever now reject. Audit
+fire-and-forget `send(...)` call sites and attach `.catch(...)`, otherwise these rejections are
+unhandled promise rejections.

--- a/README.md
+++ b/README.md
@@ -56,18 +56,23 @@ message handler has completed:
 - It **resolves** with the handler's result when the peer sends an ACK.
 - It **rejects** with a `VcmpError` when:
   - the peer's handler fails (NAK, carrying the peer's `ProblemDetail`),
-  - the underlying WebSocket is not open at the time of sending (status 503, "Session not open"),
-  - the session closes before the ACK arrives (status 503, "Session closed"), or
-  - the optional ack timeout elapses first (status 504, "Acknowledgement timeout").
+  - the underlying WebSocket is not open at the time of sending (status 503, "Session not open"), or
+  - the session closes before the ACK arrives (status 503, "Session closed").
 
-The ack timeout is **disabled by default**: how long to wait for a live-but-unresponsive peer is
-the caller's decision. Opt in via the `ackTimeout` option (milliseconds) of `VcmpClient` and
-`VcmpServer` to bound every send of that instance, or race an individual send against your own
-timer. With the timeout disabled, a send on a healthy, open session whose peer never acknowledges
-stays pending until the session closes (a dead connection is detected by the heartbeat and closed).
+There is deliberately **no library-level acknowledgement timeout**: different operations have
+vastly different legitimate durations (the ACK is only sent after the peer's handler completes),
+so bounding the wait is the caller's decision — race an individual send against your own timer
+where a bound is needed. The same policy applies in the Java implementation (vcmp-spring), where
+`VcmpCallback.await(...)` serves that purpose.
 
-Note that a `VcmpError` rejection no longer implies the peer answered: 503/504 describe local
-transport conditions, while a NAK carries the peer's own status. A rejection other than a NAK also
+A send on an open session whose peer never acknowledges stays pending until the session closes.
+A dead connection is detected by the heartbeat and closed — provided the heartbeat is running:
+`VcmpServer` initiates it automatically on every connection (`heartbeatInterval`, default 20 s),
+and both sides then watchdog it. A standalone `VcmpSession` only has this protection once
+`initiateHeartbeat` is called (or the peer initiates).
+
+Note that a `VcmpError` rejection no longer implies the peer answered: 503 describes a local
+transport condition, while a NAK carries the peer's own status. A rejection other than a NAK also
 does not imply the peer ignored the message: an ACK lost to a connection loss still means the
 handler ran. Use an idempotent retry if the operation must be applied exactly once.
 

--- a/packages/vcmp-server/src/index.ts
+++ b/packages/vcmp-server/src/index.ts
@@ -10,14 +10,6 @@ export type VcmpServerOptions = ServerOptions & {
 
 	/** The web socket server. If none is passed, one is constructed from the passed options. */
 	webSocketServer?: WebSocketServer;
-
-	/**
-	 * Optional timeout in milliseconds for awaiting the acknowledgement of a sent message.
-	 * When it elapses, the promise returned from `send` rejects with a `VcmpError` (status 504).
-	 * Disabled by default (or with a value of 0 or below): the promise then settles only on
-	 * ACK/NAK or when the session closes — bounding the wait is the caller's decision.
-	 */
-	ackTimeout?: number;
 };
 
 export type SessionConnected = (session: VcmpSession) => any;
@@ -38,7 +30,6 @@ export class VcmpServer {
 			debug,
 			heartbeatInterval = 20000,
 			webSocketServer,
-			ackTimeout,
 			...wssOptions
 		} = options || {};
 
@@ -51,7 +42,6 @@ export class VcmpServer {
 				webSocket: webSocket,
 				resolver: type => this.#handlers.get(type),
 				debug: options?.debug,
-				ackTimeout,
 			});
 
 			session.onClose = () => {
@@ -93,9 +83,10 @@ export class VcmpServer {
 
 	broadcast<T extends VcmpMessage>(message: T) {
 		for (const session of this.#sessions) {
-			// Fire-and-forget: a session may reject (e.g. closing mid-broadcast); swallow the
-			// rejection so it cannot surface as an unhandled promise rejection in the process.
-			session.send(message).catch(error => this.#debug?.warn("Broadcast send failed", error));
+			// Fire-and-forget: a session may reject (e.g. closing mid-broadcast, or the peer
+			// NAKing the message). Log the rejection even without a configured debug sink —
+			// a silently dropped NAK would be invisible to the caller and the logs alike.
+			session.send(message).catch(error => (this.#debug ?? console).warn("Broadcast send failed", error));
 		}
 	}
 

--- a/packages/vcmp-server/src/index.ts
+++ b/packages/vcmp-server/src/index.ts
@@ -12,9 +12,10 @@ export type VcmpServerOptions = ServerOptions & {
 	webSocketServer?: WebSocketServer;
 
 	/**
-	 * Timeout in milliseconds for awaiting the acknowledgement of a sent message.
+	 * Optional timeout in milliseconds for awaiting the acknowledgement of a sent message.
 	 * When it elapses, the promise returned from `send` rejects with a `VcmpError` (status 504).
-	 * A value of 0 or below disables the timeout.
+	 * Disabled by default (or with a value of 0 or below): the promise then settles only on
+	 * ACK/NAK or when the session closes — bounding the wait is the caller's decision.
 	 */
 	ackTimeout?: number;
 };
@@ -24,6 +25,7 @@ export type SessionDisconnected = (session: VcmpSession) => any;
 
 export class VcmpServer {
 	readonly #wss: WebSocketServer;
+	readonly #debug?: ConsoleLike;
 
 	readonly #handlers = new Map<string, VcmpHandler<any>>();
 	readonly #sessions = new Set<VcmpSession>();
@@ -40,6 +42,7 @@ export class VcmpServer {
 			...wssOptions
 		} = options || {};
 
+		this.#debug = debug;
 		this.#wss = webSocketServer ?? new WebSocketServer({
 			...wssOptions,
 		});
@@ -90,7 +93,9 @@ export class VcmpServer {
 
 	broadcast<T extends VcmpMessage>(message: T) {
 		for (const session of this.#sessions) {
-			session.send(message);
+			// Fire-and-forget: a session may reject (e.g. closing mid-broadcast); swallow the
+			// rejection so it cannot surface as an unhandled promise rejection in the process.
+			session.send(message).catch(error => this.#debug?.warn("Broadcast send failed", error));
 		}
 	}
 

--- a/packages/vcmp-server/src/index.ts
+++ b/packages/vcmp-server/src/index.ts
@@ -81,13 +81,25 @@ export class VcmpServer {
 		this.#handlers.delete(messageType);
 	}
 
+	/**
+	 * Broadcasts a message to every connected session.
+	 *
+	 * Returns a promise that always resolves (never rejects) with one entry per session,
+	 * carrying either the session's ACK `result` or its `error` (e.g. a NAK, or the
+	 * session closing mid-broadcast) — so callers can observe per-session failures.
+	 * Ignoring the returned promise is safe: rejections are handled internally and
+	 * reported via the debug sink.
+	 */
 	broadcast<T extends VcmpMessage>(message: T) {
-		for (const session of this.#sessions) {
-			// Fire-and-forget: a session may reject (e.g. closing mid-broadcast, or the peer
-			// NAKing the message). Log the rejection even without a configured debug sink —
-			// a silently dropped NAK would be invisible to the caller and the logs alike.
-			session.send(message).catch(error => (this.#debug ?? console).warn("Broadcast send failed", error));
-		}
+		return Promise.all([...this.#sessions].map(session =>
+			session.send(message).then(
+				result => ({session, result, error: undefined}),
+				error => {
+					this.#debug?.warn("Broadcast send failed", error);
+					return {session, result: undefined, error};
+				},
+			)
+		));
 	}
 
 	get sessions() {

--- a/packages/vcmp-server/src/index.ts
+++ b/packages/vcmp-server/src/index.ts
@@ -1,93 +1,100 @@
-import {ServerOptions, WebSocketServer} from 'ws';
 import {ConsoleLike, VcmpHandler, VcmpMessage, VcmpSession} from "@variocube/vcmp";
+import {ServerOptions, WebSocketServer} from "ws";
 
 export type VcmpServerOptions = ServerOptions & {
-    /** A sink for debug messages. */
-    debug?: ConsoleLike;
+	/** A sink for debug messages. */
+	debug?: ConsoleLike;
 
-    /** The heartbeat interval in milliseconds (default: 20000). */
-    heartbeatInterval?: number;
+	/** The heartbeat interval in milliseconds (default: 20000). */
+	heartbeatInterval?: number;
 
-    /** The web socket server. If none is passed, one is constructed from the passed options. */
-    webSocketServer?: WebSocketServer;
-}
+	/** The web socket server. If none is passed, one is constructed from the passed options. */
+	webSocketServer?: WebSocketServer;
+
+	/**
+	 * Timeout in milliseconds for awaiting the acknowledgement of a sent message.
+	 * When it elapses, the promise returned from `send` rejects with a `VcmpError` (status 504).
+	 * A value of 0 or below disables the timeout.
+	 */
+	ackTimeout?: number;
+};
 
 export type SessionConnected = (session: VcmpSession) => any;
 export type SessionDisconnected = (session: VcmpSession) => any;
 
 export class VcmpServer {
+	readonly #wss: WebSocketServer;
 
-    readonly #wss: WebSocketServer;
+	readonly #handlers = new Map<string, VcmpHandler<any>>();
+	readonly #sessions = new Set<VcmpSession>();
 
-    readonly #handlers = new Map<string, VcmpHandler<any>>();
-    readonly #sessions = new Set<VcmpSession>();
+	public onSessionConnected: SessionConnected = () => void 0;
+	public onSessionDisconnected: SessionDisconnected = () => void 0;
 
-    public onSessionConnected: SessionConnected = () => void 0;
-    public onSessionDisconnected: SessionDisconnected = () => void 0;
+	constructor(options?: VcmpServerOptions) {
+		const {
+			debug,
+			heartbeatInterval = 20000,
+			webSocketServer,
+			ackTimeout,
+			...wssOptions
+		} = options || {};
 
-    constructor(options?: VcmpServerOptions) {
-        const {
-            debug,
-            heartbeatInterval = 20000,
-            webSocketServer,
-            ...wssOptions
-        } = options || {};
+		this.#wss = webSocketServer ?? new WebSocketServer({
+			...wssOptions,
+		});
+		this.#wss.on("connection", webSocket => {
+			const session = new VcmpSession({
+				webSocket: webSocket,
+				resolver: type => this.#handlers.get(type),
+				debug: options?.debug,
+				ackTimeout,
+			});
 
+			session.onClose = () => {
+				this.#sessions.delete(session);
+				this.onSessionDisconnected(session);
+			};
 
-        this.#wss = webSocketServer ?? new WebSocketServer({
-            ...wssOptions,
-        });
-        this.#wss.on("connection", webSocket => {
-            const session = new VcmpSession({
-                webSocket: webSocket,
-                resolver: type => this.#handlers.get(type),
-                debug: options?.debug,
-            });
+			session.initiateHeartbeat(heartbeatInterval);
 
-            session.onClose = () => {
-                this.#sessions.delete(session);
-                this.onSessionDisconnected(session);
-            }
+			this.#sessions.add(session);
+			this.onSessionConnected(session);
+		});
+	}
 
-            session.initiateHeartbeat(heartbeatInterval);
+	stop() {
+		return new Promise<void>((resolve, reject) => {
+			// Close sessions
+			this.#sessions.forEach(session => session.close());
 
-            this.#sessions.add(session);
-            this.onSessionConnected(session);
-        });
-    }
+			// Close server
+			this.#wss.close(err => {
+				if (err) {
+					reject(err);
+				}
+				else {
+					resolve();
+				}
+			});
+		});
+	}
 
-    stop() {
-        return new Promise<void>((resolve, reject) => {
-            // Close sessions
-            this.#sessions.forEach(session => session.close());
+	on<T extends VcmpMessage>(messageType: string, handler: VcmpHandler<T>) {
+		this.#handlers.set(messageType, handler);
+	}
 
-            // Close server
-            this.#wss.close(err => {
-                if (err) {
-                    reject(err);
-                }
-                else {
-                    resolve();
-                }
-            });
-        });
-    }
+	off<T extends VcmpMessage>(messageType: string) {
+		this.#handlers.delete(messageType);
+	}
 
-    on<T extends VcmpMessage>(messageType: string, handler: VcmpHandler<T>) {
-        this.#handlers.set(messageType, handler);
-    }
+	broadcast<T extends VcmpMessage>(message: T) {
+		for (const session of this.#sessions) {
+			session.send(message);
+		}
+	}
 
-    off<T extends VcmpMessage>(messageType: string) {
-        this.#handlers.delete(messageType);
-    }
-
-    broadcast<T extends VcmpMessage>(message: T) {
-        for (const session of this.#sessions) {
-            session.send(message);
-        }
-    }
-
-    get sessions() {
-        return [...this.#sessions];
-    }
+	get sessions() {
+		return [...this.#sessions];
+	}
 }

--- a/packages/vcmp-server/tests/server.ts
+++ b/packages/vcmp-server/tests/server.ts
@@ -213,9 +213,10 @@ describe("VcmpServer", () => {
 		});
 		const client = await createConnectedClient("ws://localhost:12345");
 		const session = server.sessions[0];
+		// wait for the close to actually propagate to the server side
+		const disconnected = new Promise<void>(resolve => server.onSessionDisconnected = () => resolve());
 		client.stop();
-		// wait for the close to propagate to the server side
-		await sleep(20);
+		await disconnected;
 		try {
 			await session.send({"@type": "foo"});
 			expect.fail("Expected error");

--- a/packages/vcmp-server/tests/server.ts
+++ b/packages/vcmp-server/tests/server.ts
@@ -27,13 +27,13 @@ describe("VcmpServer", () => {
 			messageCount++;
 		});
 
-		server.broadcast({
+		const results = await server.broadcast({
 			"@type": "foo",
 			foo: "bar",
 		});
 
-		await sleep(20);
-
+		expect(results).to.have.length(2);
+		expect(results.filter(entry => entry.error)).to.have.length(0);
 		expect(messageCount).to.be.equal(2);
 
 		client1.stop();

--- a/packages/vcmp-server/tests/server.ts
+++ b/packages/vcmp-server/tests/server.ts
@@ -154,6 +154,81 @@ describe("VcmpServer", () => {
 			await server.stop();
 		}
 	});
+
+	it("rejects pending sends when the session closes before ack", async () => {
+		const server = new VcmpServer({
+			port: 12345,
+		});
+		// a handler that never settles, so the ACK is never sent
+		server.on("foo", () => new Promise(() => {}));
+		const client = await createConnectedClient("ws://localhost:12345");
+		const pending = client.send({"@type": "foo"});
+		// let the message reach the server, then close the session underneath the client
+		await sleep(20);
+		server.sessions.forEach(session => session.close());
+		try {
+			await pending;
+			expect.fail("Expected error");
+		}
+		catch (error) {
+			if (!(error instanceof VcmpError)) throw new Error("Expected error to be instance of VcmpError");
+			expect(error.status).to.be.equal(503);
+			expect(error.title).to.be.equal("Session closed");
+		}
+		finally {
+			client.stop();
+			await server.stop();
+		}
+	});
+
+	it("rejects pending sends when the ack timeout elapses", async () => {
+		const server = new VcmpServer({
+			port: 12345,
+		});
+		server.on("foo", () => new Promise(() => {}));
+		const client = new VcmpClient("ws://localhost:12345", {
+			autoStart: true,
+			customWebSocket: NodeWebSocket,
+			ackTimeout: 100,
+		});
+		await awaitConnected(client);
+		try {
+			await client.send({"@type": "foo"});
+			expect.fail("Expected error");
+		}
+		catch (error) {
+			if (!(error instanceof VcmpError)) throw new Error("Expected error to be instance of VcmpError");
+			expect(error.status).to.be.equal(504);
+			expect(error.title).to.be.equal("Acknowledgement timeout");
+		}
+		finally {
+			client.stop();
+			await server.stop();
+		}
+	});
+
+	it("rejects sends on a session that is not open", async () => {
+		const server = new VcmpServer({
+			port: 12345,
+		});
+		const client = await createConnectedClient("ws://localhost:12345");
+		const session = server.sessions[0];
+		client.stop();
+		// wait for the close to propagate to the server side
+		await sleep(20);
+		try {
+			await session.send({"@type": "foo"});
+			expect.fail("Expected error");
+		}
+		catch (error) {
+			if (!(error instanceof VcmpError)) throw new Error("Expected error to be instance of VcmpError");
+			expect(error.status).to.be.equal(503);
+			expect(error.title).to.be.equal("Session not open");
+		}
+		finally {
+			await server.stop();
+		}
+	});
 });
 
 async function createConnectedClient(url: string) {

--- a/packages/vcmp-server/tests/server.ts
+++ b/packages/vcmp-server/tests/server.ts
@@ -181,32 +181,6 @@ describe("VcmpServer", () => {
 		}
 	});
 
-	it("rejects pending sends when the ack timeout elapses", async () => {
-		const server = new VcmpServer({
-			port: 12345,
-		});
-		server.on("foo", () => new Promise(() => {}));
-		const client = new VcmpClient("ws://localhost:12345", {
-			autoStart: true,
-			customWebSocket: NodeWebSocket,
-			ackTimeout: 100,
-		});
-		await awaitConnected(client);
-		try {
-			await client.send({"@type": "foo"});
-			expect.fail("Expected error");
-		}
-		catch (error) {
-			if (!(error instanceof VcmpError)) throw new Error("Expected error to be instance of VcmpError");
-			expect(error.status).to.be.equal(504);
-			expect(error.title).to.be.equal("Acknowledgement timeout");
-		}
-		finally {
-			client.stop();
-			await server.stop();
-		}
-	});
-
 	it("rejects sends on a session that is not open", async () => {
 		const server = new VcmpServer({
 			port: 12345,

--- a/packages/vcmp/src/client.ts
+++ b/packages/vcmp/src/client.ts
@@ -1,154 +1,161 @@
-import {CloseHandler, ConsoleLike, OpenHandler, VcmpHandler, VcmpMessage} from "./types";
-import {VcmpSession} from "./session";
 import NodeWebSocket from "ws";
+import {VcmpSession} from "./session";
+import {CloseHandler, ConsoleLike, OpenHandler, VcmpHandler, VcmpMessage} from "./types";
 
 export interface Options {
-    reconnectTimeout: number;
-    autoStart: boolean;
-    customWebSocket?: (typeof NodeWebSocket) | (typeof WebSocket);
-    debug?: ConsoleLike;
+	reconnectTimeout: number;
+	autoStart: boolean;
+	customWebSocket?: (typeof NodeWebSocket) | (typeof WebSocket);
+	debug?: ConsoleLike;
+	/**
+	 * Timeout in milliseconds for awaiting the acknowledgement of a sent message.
+	 * When it elapses, the promise returned from `send` rejects with a `VcmpError` (status 504).
+	 * Defaults to `DEFAULT_ACK_TIMEOUT`. A value of 0 or below disables the timeout.
+	 */
+	ackTimeout?: number;
 }
 
 const defaultOptions: Options = {
-    reconnectTimeout: 10000,
-    autoStart: false,
+	reconnectTimeout: 10000,
+	autoStart: false,
 };
 
 export class VcmpClient {
+	private readonly url: string;
+	private readonly options: Options;
 
-    private readonly url: string;
-    private readonly options: Options;
+	private running = false;
+	private waitingForReconnect = false;
+	private session?: VcmpSession;
 
-    private running = false;
-    private waitingForReconnect = false;
-    private session?: VcmpSession;
+	private reconnectTimeout?: number | NodeJS.Timeout;
 
-    private reconnectTimeout?: number | NodeJS.Timeout;
+	private handler = new Map<string, VcmpHandler<any>>();
 
-    private handler = new Map<string, VcmpHandler<any>>();
+	public onOpen?: OpenHandler;
+	public onClose?: CloseHandler;
 
-    public onOpen?: OpenHandler;
-    public onClose?: CloseHandler;
+	constructor(url: string, options?: Partial<Options>) {
+		this.url = url;
 
-    constructor(url: string, options?: Partial<Options>) {
+		this.options = {
+			...defaultOptions,
+			...options,
+		};
 
-        this.url = url;
+		this.debug(`Constructed VcmpClient for URL ${this.url} and the following options`, this.options);
 
-        this.options = {
-            ...defaultOptions,
-            ...options,
-        };
+		if (this.options.autoStart) {
+			this.debug(`Autostarting VcmpClient for URL: ${this.url}`);
+			this.start();
+		}
+	}
 
-        this.debug(`Constructed VcmpClient for URL ${this.url} and the following options`, this.options);
+	start() {
+		this.debug(`Starting VcmpClient for URL: ${this.url}`);
+		this.running = true;
+		this.initiateConnection();
+	}
 
-        if (this.options.autoStart) {
-            this.debug(`Autostarting VcmpClient for URL: ${this.url}`);
-            this.start();
-        }
-    }
+	stop() {
+		this.debug(`Stopping VcmpClient for URL: ${this.url}`);
+		this.running = false;
+		if (this.reconnectTimeout) {
+			clearTimeout(this.reconnectTimeout as any);
+		}
+		if (this.session) {
+			this.debug(`Closing VCMP session`);
+			this.session.close();
+		}
+	}
 
-    start() {
-        this.debug(`Starting VcmpClient for URL: ${this.url}`);
-        this.running = true;
-        this.initiateConnection();
-    }
+	get connected() {
+		return this.session?.isOpen;
+	}
 
-    stop() {
-        this.debug(`Stopping VcmpClient for URL: ${this.url}`);
-        this.running = false;
-        if (this.reconnectTimeout) {
-            clearTimeout(this.reconnectTimeout as any);
-        }
-        if (this.session) {
-            this.debug(`Closing VCMP session`);
-            this.session.close();
-        }
-    }
+	send<T extends VcmpMessage>(message: T) {
+		this.debug("Sending VcmpMessage", message);
+		if (this.session) {
+			return this.session.send(message);
+		}
+		else {
+			return Promise.reject(new Error("No session."));
+		}
+	}
 
-    get connected() {
-        return this.session?.isOpen;
-    }
+	private initiateConnection = () => {
+		this.debug("Initiating connection");
+		if (this.running) {
+			this.debug("Initiating connection");
+			const webSocketConstructor = this.options.customWebSocket || WebSocket;
+			if (typeof webSocketConstructor !== "function") {
+				throw new Error(
+					"WebSocket constructor not found. If running on Node, please install the `ws` package and pass it as customWebSocket in options.",
+				);
+			}
 
-    send<T extends VcmpMessage>(message: T) {
-        this.debug("Sending VcmpMessage", message);
-        if (this.session) {
-            return this.session.send(message);
-        }
-        else {
-            return Promise.reject(new Error("No session."));
-        }
-    }
+			this.debug("Constructing websocket");
+			const webSocket = new webSocketConstructor(this.url);
+			this.debug("Connecting handlers");
+			this.session = new VcmpSession({
+				webSocket,
+				resolver: type => this.handler.get(type),
+				debug: this.options.debug,
+				ackTimeout: this.options.ackTimeout,
+			});
+			this.session.onOpen = this.handleOpen;
+			this.session.onClose = this.handleClose;
+		}
+		else {
+			this.debug("Already running, ignoring call to initiateConnection");
+		}
+	};
 
-    private initiateConnection = () => {
-        this.debug("Initiating connection");
-        if (this.running) {
-            this.debug("Initiating connection");
-            const webSocketConstructor = this.options.customWebSocket || WebSocket;
-            if (typeof webSocketConstructor !== "function") {
-                throw new Error("WebSocket constructor not found. If running on Node, please install the `ws` package and pass it as customWebSocket in options.");
-            }
+	on<T>(type: string, handler: VcmpHandler<T>) {
+		this.handler.set(type, handler);
+	}
 
-            this.debug("Constructing websocket");
-            const webSocket = new webSocketConstructor(this.url);
-            this.debug("Connecting handlers");
-            this.session = new VcmpSession({
-                webSocket,
-                resolver: type => this.handler.get(type),
-                debug: this.options.debug
-            });
-            this.session.onOpen = this.handleOpen;
-            this.session.onClose = this.handleClose;
-        }
-        else {
-            this.debug("Already running, ignoring call to initiateConnection");
-        }
-    };
+	off(type: string) {
+		this.handler.delete(type);
+	}
 
-    on<T>(type: string, handler: VcmpHandler<T>) {
-        this.handler.set(type, handler);
-    }
+	private scheduleReconnect() {
+		this.debug("Checking whether to schedule reconnect.");
+		this.session = undefined;
+		if (this.running && !this.waitingForReconnect) {
+			this.debug("Scheduling reconnect.");
+			this.waitingForReconnect = true;
+			this.reconnectTimeout = setTimeout(() => {
+				this.waitingForReconnect = false;
+				this.initiateConnection();
+			}, this.options.reconnectTimeout);
+		}
+	}
 
-    off(type: string) {
-        this.handler.delete(type);
-    }
+	private handleOpen = () => {
+		this.debug("VCMP session open");
+		this.onOpen && this.onOpen();
+	};
 
-    private scheduleReconnect() {
-        this.debug("Checking whether to schedule reconnect.");
-        this.session = undefined;
-        if (this.running && !this.waitingForReconnect) {
-            this.debug("Scheduling reconnect.");
-            this.waitingForReconnect = true;
-            this.reconnectTimeout = setTimeout(() => {
-                this.waitingForReconnect = false;
-                this.initiateConnection();
-            }, this.options.reconnectTimeout);
-        }
-    }
+	private handleClose = () => {
+		this.debug("VCMP session closed");
+		this.onClose && this.onClose();
+		this.scheduleReconnect();
+	};
 
-    private handleOpen = () => {
-        this.debug("VCMP session open");
-        this.onOpen && this.onOpen();
-    };
+	private info(...data: any[]) {
+		this.options.debug?.info(...data);
+	}
 
-    private handleClose = () => {
-        this.debug("VCMP session closed");
-        this.onClose && this.onClose();
-        this.scheduleReconnect();
-    };
+	private debug(...data: any[]) {
+		this.options.debug?.debug(...data);
+	}
 
-    private info(...data: any[]) {
-        this.options.debug?.info(...data);
-    }
+	private warn(...data: any[]) {
+		this.options.debug?.warn(...data);
+	}
 
-    private debug(...data: any[]) {
-        this.options.debug?.debug(...data);
-    }
-
-    private warn(...data: any[]) {
-        this.options.debug?.warn(...data);
-    }
-
-    private error(...data: any[]) {
-        this.options.debug?.error(...data);
-    }
+	private error(...data: any[]) {
+		this.options.debug?.error(...data);
+	}
 }

--- a/packages/vcmp/src/client.ts
+++ b/packages/vcmp/src/client.ts
@@ -48,6 +48,11 @@ export class VcmpClient {
 
 	start() {
 		this.debug(`Starting VcmpClient for URL: ${this.url}`);
+		// Cancel a pending reconnect and discard an existing session: this call replaces
+		// both with a fresh connection. Otherwise a still-armed reconnect timer would fire
+		// later and open a second, duplicate connection.
+		this.cancelReconnect();
+		this.discardSession();
 		this.running = true;
 		this.initiateConnection();
 	}
@@ -55,19 +60,34 @@ export class VcmpClient {
 	stop() {
 		this.debug(`Stopping VcmpClient for URL: ${this.url}`);
 		this.running = false;
+		this.cancelReconnect();
+		this.discardSession();
+	}
+
+	private cancelReconnect() {
 		if (this.reconnectTimeout) {
 			clearTimeout(this.reconnectTimeout as any);
 		}
-		// Reset the flag so a later start() can schedule reconnects again;
+		// Reset the flag so a later disconnect can schedule reconnects again;
 		// otherwise the cleared timer above would never clear it.
 		this.waitingForReconnect = false;
+	}
+
+	private discardSession() {
 		const session = this.session;
 		if (session) {
 			this.debug(`Closing VCMP session`);
 			// Detach the reconnect logic before closing: the socket's close event arrives
 			// asynchronously, and must not discard a session created by a later start().
 			this.session = undefined;
-			session.onClose = () => this.onClose && this.onClose();
+			session.onClose = () => {
+				// Only notify if no new session has been created since: a late close event
+				// of the old socket must not signal "closed" to an application that has
+				// already moved on to a new session.
+				if (!this.session) {
+					this.onClose && this.onClose();
+				}
+			};
 			session.close();
 		}
 	}
@@ -93,7 +113,6 @@ export class VcmpClient {
 	}
 
 	private initiateConnection = () => {
-		this.debug("Initiating connection");
 		if (this.running) {
 			this.debug("Initiating connection");
 			const webSocketConstructor = this.options.customWebSocket || WebSocket;
@@ -106,16 +125,19 @@ export class VcmpClient {
 			this.debug("Constructing websocket");
 			const webSocket = new webSocketConstructor(this.url);
 			this.debug("Connecting handlers");
-			this.session = new VcmpSession({
+			const session = new VcmpSession({
 				webSocket,
 				resolver: type => this.handler.get(type),
 				debug: this.options.debug,
 			});
-			this.session.onOpen = this.handleOpen;
-			this.session.onClose = this.handleClose;
+			this.session = session;
+			session.onOpen = this.handleOpen;
+			// Capture the session: a close event may arrive after this session has been
+			// replaced, and must not affect the session that replaced it.
+			session.onClose = () => this.handleSessionClose(session);
 		}
 		else {
-			this.debug("Already running, ignoring call to initiateConnection");
+			this.debug("Not running, ignoring call to initiateConnection");
 		}
 	};
 
@@ -145,11 +167,15 @@ export class VcmpClient {
 		this.onOpen && this.onOpen();
 	};
 
-	private handleClose = () => {
+	private handleSessionClose(session: VcmpSession) {
+		if (this.session !== session) {
+			this.debug("Ignoring close event of a replaced session");
+			return;
+		}
 		this.debug("VCMP session closed");
 		this.onClose && this.onClose();
 		this.scheduleReconnect();
-	};
+	}
 
 	private info(...data: any[]) {
 		this.options.debug?.info(...data);

--- a/packages/vcmp/src/client.ts
+++ b/packages/vcmp/src/client.ts
@@ -1,4 +1,5 @@
 import NodeWebSocket from "ws";
+import {VcmpError} from "./error";
 import {VcmpSession} from "./session";
 import {CloseHandler, ConsoleLike, OpenHandler, VcmpHandler, VcmpMessage} from "./types";
 
@@ -8,9 +9,10 @@ export interface Options {
 	customWebSocket?: (typeof NodeWebSocket) | (typeof WebSocket);
 	debug?: ConsoleLike;
 	/**
-	 * Timeout in milliseconds for awaiting the acknowledgement of a sent message.
+	 * Optional timeout in milliseconds for awaiting the acknowledgement of a sent message.
 	 * When it elapses, the promise returned from `send` rejects with a `VcmpError` (status 504).
-	 * Defaults to `DEFAULT_ACK_TIMEOUT`. A value of 0 or below disables the timeout.
+	 * Disabled by default (or with a value of 0 or below): the promise then settles only on
+	 * ACK/NAK or when the session closes — bounding the wait is the caller's decision.
 	 */
 	ackTimeout?: number;
 }
@@ -63,6 +65,9 @@ export class VcmpClient {
 		if (this.reconnectTimeout) {
 			clearTimeout(this.reconnectTimeout as any);
 		}
+		// Reset the flag so a later start() can schedule reconnects again;
+		// otherwise the cleared timer above would never clear it.
+		this.waitingForReconnect = false;
 		if (this.session) {
 			this.debug(`Closing VCMP session`);
 			this.session.close();
@@ -79,7 +84,13 @@ export class VcmpClient {
 			return this.session.send(message);
 		}
 		else {
-			return Promise.reject(new Error("No session."));
+			return Promise.reject(
+				new VcmpError({
+					title: "Session not open",
+					status: 503,
+					detail: "Cannot send message: the client has no session.",
+				}),
+			);
 		}
 	}
 

--- a/packages/vcmp/src/client.ts
+++ b/packages/vcmp/src/client.ts
@@ -6,6 +6,14 @@ import {CloseHandler, ConsoleLike, OpenHandler, VcmpHandler, VcmpMessage} from "
 export interface Options {
 	reconnectTimeout: number;
 	autoStart: boolean;
+	/**
+	 * Time in milliseconds within which the server must initiate a heartbeat after the
+	 * connection opens; the session is closed (and reconnected) otherwise. This guards
+	 * against a half-open connection through which no heartbeat ever arrives — without
+	 * a running heartbeat, nothing would settle pending sends when the connection dies.
+	 * A value of 0 or below disables the expectation. Default: 60000.
+	 */
+	initialHeartbeatTimeout: number;
 	customWebSocket?: (typeof NodeWebSocket) | (typeof WebSocket);
 	debug?: ConsoleLike;
 }
@@ -13,6 +21,7 @@ export interface Options {
 const defaultOptions: Options = {
 	reconnectTimeout: 10000,
 	autoStart: false,
+	initialHeartbeatTimeout: 60000,
 };
 
 export class VcmpClient {
@@ -52,7 +61,7 @@ export class VcmpClient {
 		// both with a fresh connection. Otherwise a still-armed reconnect timer would fire
 		// later and open a second, duplicate connection.
 		this.cancelReconnect();
-		this.discardSession();
+		this.discardSession(true);
 		this.running = true;
 		this.initiateConnection();
 	}
@@ -61,7 +70,7 @@ export class VcmpClient {
 		this.debug(`Stopping VcmpClient for URL: ${this.url}`);
 		this.running = false;
 		this.cancelReconnect();
-		this.discardSession();
+		this.discardSession(false);
 	}
 
 	private cancelReconnect() {
@@ -73,17 +82,18 @@ export class VcmpClient {
 		this.waitingForReconnect = false;
 	}
 
-	private discardSession() {
+	private discardSession(replacing: boolean) {
 		const session = this.session;
 		if (session) {
 			this.debug(`Closing VCMP session`);
-			// Detach the reconnect logic before closing: the socket's close event arrives
-			// asynchronously, and must not discard a session created by a later start().
+			// Detach the handlers before closing: the socket's events arrive asynchronously,
+			// and must not affect a session created by a later start() — neither by firing
+			// the application's onOpen/onClose nor by scheduling a reconnect.
 			this.session = undefined;
-			session.onClose = () => {
-				// Only notify if no new session has been created since: a late close event
-				// of the old socket must not signal "closed" to an application that has
-				// already moved on to a new session.
+			session.onOpen = undefined;
+			// When a replacement follows (start()), suppress the close notification
+			// entirely; otherwise (stop()) notify unless a new session appeared since.
+			session.onClose = replacing ? undefined : () => {
 				if (!this.session) {
 					this.onClose && this.onClose();
 				}
@@ -131,9 +141,9 @@ export class VcmpClient {
 				debug: this.options.debug,
 			});
 			this.session = session;
-			session.onOpen = this.handleOpen;
-			// Capture the session: a close event may arrive after this session has been
+			// Capture the session: an event may arrive after this session has been
 			// replaced, and must not affect the session that replaced it.
+			session.onOpen = () => this.handleSessionOpen(session);
 			session.onClose = () => this.handleSessionClose(session);
 		}
 		else {
@@ -162,10 +172,19 @@ export class VcmpClient {
 		}
 	}
 
-	private handleOpen = () => {
+	private handleSessionOpen(session: VcmpSession) {
+		if (this.session !== session) {
+			this.debug("Ignoring open event of a replaced session");
+			return;
+		}
 		this.debug("VCMP session open");
+		// The server initiates the heartbeat; expect it to arrive, so that a half-open
+		// connection through which no heartbeat ever comes is detected and closed.
+		if (this.options.initialHeartbeatTimeout > 0) {
+			session.expectHeartbeat(this.options.initialHeartbeatTimeout);
+		}
 		this.onOpen && this.onOpen();
-	};
+	}
 
 	private handleSessionClose(session: VcmpSession) {
 		if (this.session !== session) {

--- a/packages/vcmp/src/client.ts
+++ b/packages/vcmp/src/client.ts
@@ -8,13 +8,6 @@ export interface Options {
 	autoStart: boolean;
 	customWebSocket?: (typeof NodeWebSocket) | (typeof WebSocket);
 	debug?: ConsoleLike;
-	/**
-	 * Optional timeout in milliseconds for awaiting the acknowledgement of a sent message.
-	 * When it elapses, the promise returned from `send` rejects with a `VcmpError` (status 504).
-	 * Disabled by default (or with a value of 0 or below): the promise then settles only on
-	 * ACK/NAK or when the session closes — bounding the wait is the caller's decision.
-	 */
-	ackTimeout?: number;
 }
 
 const defaultOptions: Options = {
@@ -68,9 +61,14 @@ export class VcmpClient {
 		// Reset the flag so a later start() can schedule reconnects again;
 		// otherwise the cleared timer above would never clear it.
 		this.waitingForReconnect = false;
-		if (this.session) {
+		const session = this.session;
+		if (session) {
 			this.debug(`Closing VCMP session`);
-			this.session.close();
+			// Detach the reconnect logic before closing: the socket's close event arrives
+			// asynchronously, and must not discard a session created by a later start().
+			this.session = undefined;
+			session.onClose = () => this.onClose && this.onClose();
+			session.close();
 		}
 	}
 
@@ -112,7 +110,6 @@ export class VcmpClient {
 				webSocket,
 				resolver: type => this.handler.get(type),
 				debug: this.options.debug,
-				ackTimeout: this.options.ackTimeout,
 			});
 			this.session.onOpen = this.handleOpen;
 			this.session.onClose = this.handleClose;

--- a/packages/vcmp/src/session.ts
+++ b/packages/vcmp/src/session.ts
@@ -10,19 +10,15 @@ type PromiseCallbacks = {
 	timeout?: number | NodeJS.Timeout;
 };
 
-/**
- * Default timeout for awaiting the acknowledgement of a sent message.
- */
-export const DEFAULT_ACK_TIMEOUT = 30000;
-
 interface VcmpSessionOptions {
 	webSocket: WebSocket | NodeWebSocket;
 	resolver: (type: string) => VcmpHandler<any> | undefined;
 	debug?: ConsoleLike;
 	/**
-	 * Timeout in milliseconds for awaiting the acknowledgement of a sent message.
+	 * Optional timeout in milliseconds for awaiting the acknowledgement of a sent message.
 	 * When it elapses, the promise returned from `send` rejects with a `VcmpError` (status 504).
-	 * Defaults to `DEFAULT_ACK_TIMEOUT`. A value of 0 or below disables the timeout.
+	 * Disabled by default (or with a value of 0 or below): the promise then settles only on
+	 * ACK/NAK or when the session closes — bounding the wait is the caller's decision.
 	 */
 	ackTimeout?: number;
 }
@@ -37,7 +33,7 @@ export class VcmpSession {
 		this.webSocket = webSocket;
 		this.resolver = resolver;
 		this.debug = debug;
-		this.ackTimeout = ackTimeout ?? DEFAULT_ACK_TIMEOUT;
+		this.ackTimeout = ackTimeout ?? 0;
 	}
 
 	private readonly webSocket: WebSocket | NodeWebSocket;
@@ -69,6 +65,10 @@ export class VcmpSession {
 			}
 			const payload = JSON.stringify(message);
 			const id = generateVcmpFrameId();
+			// Send before registering the callbacks entry: if sendFrame throws synchronously,
+			// the executor rejects the promise and no entry or timer is left behind. The ACK
+			// cannot overtake the registration, since it arrives on a later event-loop turn.
+			this.sendFrame({type: "MSG", id, payload});
 			const timeout = this.ackTimeout > 0
 				? setTimeout(() =>
 					this.failPendingMessage(
@@ -81,7 +81,6 @@ export class VcmpSession {
 					), this.ackTimeout)
 				: undefined;
 			this.callbacks.set(id, {resolve, reject, timeout});
-			this.sendFrame({type: "MSG", id, payload});
 		});
 	}
 
@@ -100,19 +99,40 @@ export class VcmpSession {
 	private handleAck(frameId: string, payload: string | undefined) {
 		const promise = this.takePendingMessage(frameId);
 		if (promise) {
-			const result = payload ? JSON.parse(payload) : undefined;
-			promise.resolve(result);
+			try {
+				const result = payload ? JSON.parse(payload) : undefined;
+				promise.resolve(result);
+			}
+			catch (error) {
+				promise.reject(
+					new VcmpError({
+						title: "Invalid acknowledgement",
+						status: 500,
+						detail: "The ACK payload could not be parsed.",
+					}),
+				);
+			}
 		}
 	}
 
 	private handleNak(frameId: string, payload: string | undefined) {
 		const promise = this.takePendingMessage(frameId);
 		if (promise) {
-			const error = payload ? createVcmpError(JSON.parse(payload)) : new VcmpError({
-				title: "Message handling failed",
-				status: 500,
-				detail: "Unspecified error in message handling.",
-			});
+			let error: VcmpError;
+			try {
+				error = payload ? createVcmpError(JSON.parse(payload)) : new VcmpError({
+					title: "Message handling failed",
+					status: 500,
+					detail: "Unspecified error in message handling.",
+				});
+			}
+			catch (parseError) {
+				error = new VcmpError({
+					title: "Message handling failed",
+					status: 500,
+					detail: "The NAK payload could not be parsed.",
+				});
+			}
 			promise.reject(error);
 		}
 	}
@@ -260,7 +280,7 @@ export class VcmpSession {
 						this.sendFrame({
 							type: "ACK",
 							id: frameId,
-							payload: result ? JSON.stringify(result) : undefined,
+							payload: result !== undefined ? JSON.stringify(result) : undefined,
 						});
 					}
 					catch (error) {

--- a/packages/vcmp/src/session.ts
+++ b/packages/vcmp/src/session.ts
@@ -63,7 +63,13 @@ export class VcmpSession {
 			}
 			catch (error) {
 				this.callbacks.delete(id);
-				throw error;
+				// Wrap so that every rejection of send() is a VcmpError, as documented.
+				throw new VcmpError({
+					title: "Send failed",
+					status: 503,
+					detail: "The message could not be sent.",
+					cause: error,
+				});
 			}
 		});
 	}
@@ -242,21 +248,38 @@ export class VcmpSession {
 	};
 
 	private sendHeartbeat(frame: VcmpHeartbeatFrame) {
+		// Never send or arm the watchdog on a session that is not open — otherwise the
+		// watchdog would close a healthy connection whose heartbeat was never actually
+		// sent. Mirrors the Java implementation (vcmp-spring).
+		if (!this.isOpen) {
+			this.debug?.warn("Not sending heartbeat: the WebSocket is not open.");
+			return;
+		}
+
 		this.debug?.debug("Sending heartbeat.");
 
 		// set the flag that we await a heartbeat
 		this.awaitingHeartbeat = true;
 
-		// Arm the watchdog before sending: if the peer never sends a heartbeat back
-		// within 2 x interval, the connection is considered dead and closed. This also
-		// covers a peer that connects but never answers the initial heartbeat at all.
+		try {
+			this.sendFrame(frame);
+		}
+		catch (error) {
+			// The connection is in an uncertain state — close it, which settles all
+			// pending sends via the close path. Mirrors the Java implementation.
+			this.debug?.warn("Could not send heartbeat. Closing session.", error);
+			this.close();
+			return;
+		}
+
+		// Arm the watchdog after a successful send: if the peer never sends a heartbeat
+		// back within 2 x interval, the connection is considered dead and closed. This
+		// also covers a peer that connects but never answers the initial heartbeat at all.
 		clearTimeout(this.heartbeatReceiveTimeout as any);
 		this.heartbeatReceiveTimeout = setTimeout(() => {
 			this.debug?.warn("Did not receive heartbeat in time. Closing session.");
 			this.close();
 		}, 2 * frame.heartbeatInterval);
-
-		this.trySendFrame(frame);
 	}
 
 	private handleHeartbeatReceived(frame: VcmpHeartbeatFrame) {
@@ -314,11 +337,24 @@ export class VcmpSession {
 					}
 					catch (error) {
 						this.debug?.warn("Error in handler, sending NAK", error);
-						this.trySendFrame({
-							type: "NAK",
-							id: frameId,
-							payload: JSON.stringify(createVcmpError(error)),
-						});
+						// Serializing the handler's error can itself throw (circular
+						// references, BigInt); nothing awaits this callback, so a throw
+						// here would be an unhandled promise rejection.
+						let nakPayload: string;
+						try {
+							nakPayload = JSON.stringify(createVcmpError(error));
+						}
+						catch (serializationError) {
+							this.debug?.warn("Could not serialize handler error", serializationError);
+							nakPayload = JSON.stringify(
+								new VcmpError({
+									title: "Message handling failed",
+									status: 500,
+									detail: "The handler error could not be serialized.",
+								}),
+							);
+						}
+						this.trySendFrame({type: "NAK", id: frameId, payload: nakPayload});
 					}
 				});
 			}

--- a/packages/vcmp/src/session.ts
+++ b/packages/vcmp/src/session.ts
@@ -37,6 +37,7 @@ export class VcmpSession {
 	private heartbeatTimeout?: number | NodeJS.Timeout;
 	private heartbeatReceiveTimeout?: number | NodeJS.Timeout;
 	private awaitingHeartbeat = true;
+	private initiatedHeartbeatInterval?: number;
 
 	private callbacks = new Map<string, PromiseCallbacks>();
 
@@ -83,7 +84,26 @@ export class VcmpSession {
 	}
 
 	initiateHeartbeat(heartbeatInterval: number) {
-		this.sendHeartbeat({type: "HBT", heartbeatInterval});
+		this.initiatedHeartbeatInterval = heartbeatInterval;
+		if (this.isOpen) {
+			this.sendHeartbeat({type: "HBT", heartbeatInterval});
+		}
+		// otherwise the heartbeat starts once the socket opens (see handleOpen) —
+		// initiating on a still-CONNECTING socket must not silently disable it
+	}
+
+	/**
+	 * Expects the peer to send a heartbeat within the given time, closing the session
+	 * otherwise. Meant for the non-initiating side, whose watchdog otherwise only starts
+	 * with the first received heartbeat — without this, a peer that completes the
+	 * handshake but never sends anything would go undetected.
+	 */
+	expectHeartbeat(timeoutMs: number) {
+		clearTimeout(this.heartbeatReceiveTimeout as any);
+		this.heartbeatReceiveTimeout = setTimeout(() => {
+			this.debug?.warn("Did not receive the expected heartbeat. Closing session.");
+			this.close();
+		}, timeoutMs);
 	}
 
 	private handleAck(frameId: string, payload: string | undefined) {
@@ -181,6 +201,10 @@ export class VcmpSession {
 	private handleOpen = () => {
 		this.debug?.debug("WebSocket session open");
 		this.awaitingHeartbeat = true;
+		// start a heartbeat that was initiated while the socket was still connecting
+		if (this.initiatedHeartbeatInterval) {
+			this.sendHeartbeat({type: "HBT", heartbeatInterval: this.initiatedHeartbeatInterval});
+		}
 		this.onOpen && this.onOpen();
 	};
 
@@ -283,6 +307,13 @@ export class VcmpSession {
 	}
 
 	private handleHeartbeatReceived(frame: VcmpHeartbeatFrame) {
+		// Guard against a malformed HBT frame: a missing or garbled interval parses to
+		// NaN, and NaN timeouts coerce to 0 — which would echo "HBTNaN" and let the
+		// watchdog close the session within the same tick.
+		if (!Number.isFinite(frame.heartbeatInterval) || frame.heartbeatInterval <= 0) {
+			this.debug?.warn("Ignoring heartbeat with invalid interval", frame.heartbeatInterval);
+			return;
+		}
 		// check whether we are currently awaiting a heartbeat
 		if (this.awaitingHeartbeat) {
 			// clear the flag that we are awaiting a heartbeat

--- a/packages/vcmp/src/session.ts
+++ b/packages/vcmp/src/session.ts
@@ -1,210 +1,281 @@
+import NodeWebSocket, {MessageEvent} from "ws";
+import {asyncExecute} from "./asyncExecute";
+import {createVcmpError, VcmpError} from "./error";
 import {generateVcmpFrameId, parseVcmpFrame, serializeVcmpFrame, VcmpFrame, VcmpHeartbeatFrame} from "./frame";
 import {CloseHandler, ConsoleLike, OpenHandler, VcmpHandler, VcmpMessage} from "./types";
-import {asyncExecute} from "./asyncExecute";
-import NodeWebSocket, {MessageEvent} from "ws";
-import {createVcmpError, VcmpError} from "./error";
 
 type PromiseCallbacks = {
-    resolve: (result?: any) => void;
-    reject: (reason?: any) => void;
-}
+	resolve: (result?: any) => void;
+	reject: (reason?: any) => void;
+	timeout?: number | NodeJS.Timeout;
+};
+
+/**
+ * Default timeout for awaiting the acknowledgement of a sent message.
+ */
+export const DEFAULT_ACK_TIMEOUT = 30000;
 
 interface VcmpSessionOptions {
-    webSocket: WebSocket | NodeWebSocket;
-    resolver: (type: string) => VcmpHandler<any> | undefined;
-    debug?: ConsoleLike;
+	webSocket: WebSocket | NodeWebSocket;
+	resolver: (type: string) => VcmpHandler<any> | undefined;
+	debug?: ConsoleLike;
+	/**
+	 * Timeout in milliseconds for awaiting the acknowledgement of a sent message.
+	 * When it elapses, the promise returned from `send` rejects with a `VcmpError` (status 504).
+	 * Defaults to `DEFAULT_ACK_TIMEOUT`. A value of 0 or below disables the timeout.
+	 */
+	ackTimeout?: number;
 }
 
-
 export class VcmpSession {
+	constructor({webSocket, resolver, debug, ackTimeout}: VcmpSessionOptions) {
+		webSocket.onmessage = this.handleMessage;
+		webSocket.onerror = this.handleError;
+		webSocket.onopen = this.handleOpen;
+		webSocket.onclose = this.handleClose;
 
-    constructor({webSocket, resolver, debug}: VcmpSessionOptions) {
+		this.webSocket = webSocket;
+		this.resolver = resolver;
+		this.debug = debug;
+		this.ackTimeout = ackTimeout ?? DEFAULT_ACK_TIMEOUT;
+	}
 
-        webSocket.onmessage = this.handleMessage;
-        webSocket.onerror = this.handleError;
-        webSocket.onopen = this.handleOpen;
-        webSocket.onclose = this.handleClose;
+	private readonly webSocket: WebSocket | NodeWebSocket;
+	private readonly resolver: (type: string) => VcmpHandler<any> | undefined;
+	private readonly debug?: ConsoleLike;
+	private readonly ackTimeout: number;
 
-        this.webSocket = webSocket;
-        this.resolver = resolver;
-        this.debug = debug;
-    }
+	public onOpen?: OpenHandler;
+	public onClose?: CloseHandler;
 
-    private readonly webSocket: WebSocket | NodeWebSocket;
-    private readonly resolver: (type: string) => VcmpHandler<any> | undefined;
-    private readonly debug?: ConsoleLike;
+	private heartbeatTimeout?: number | NodeJS.Timeout;
+	private heartbeatReceiveTimeout?: number | NodeJS.Timeout;
+	private awaitingHeartbeat = true;
 
-    public onOpen?: OpenHandler;
-    public onClose?: CloseHandler;
+	private callbacks = new Map<string, PromiseCallbacks>();
 
-    private heartbeatTimeout?: number | NodeJS.Timeout;
-    private heartbeatReceiveTimeout?: number | NodeJS.Timeout;
-    private awaitingHeartbeat = true;
+	send<T extends VcmpMessage>(message: T) {
+		this.debug?.debug("Sending VcmpMessage", message);
+		return new Promise<any>((resolve, reject) => {
+			if (!this.isOpen) {
+				reject(
+					new VcmpError({
+						title: "Session not open",
+						status: 503,
+						detail: "Cannot send message: the WebSocket is not open.",
+					}),
+				);
+				return;
+			}
+			const payload = JSON.stringify(message);
+			const id = generateVcmpFrameId();
+			const timeout = this.ackTimeout > 0
+				? setTimeout(() =>
+					this.failPendingMessage(
+						id,
+						new VcmpError({
+							title: "Acknowledgement timeout",
+							status: 504,
+							detail: `The message was not acknowledged within ${this.ackTimeout} ms.`,
+						}),
+					), this.ackTimeout)
+				: undefined;
+			this.callbacks.set(id, {resolve, reject, timeout});
+			this.sendFrame({type: "MSG", id, payload});
+		});
+	}
 
-    private callbacks = new Map<string, PromiseCallbacks>();
+	close() {
+		this.webSocket.close();
+	}
 
-    send<T extends VcmpMessage>(message: T) {
-        this.debug?.debug("Sending VcmpMessage", message);
-        return new Promise<any>((resolve, reject) => {
-            const payload = JSON.stringify(message);
-            const id = generateVcmpFrameId();
-            this.callbacks.set(id, {resolve, reject});
-            this.sendFrame({type: "MSG", id, payload});
-        });
-    }
+	get isOpen() {
+		return this.webSocket.readyState == 1; // 1...OPEN
+	}
 
-    close() {
-        this.webSocket.close();
-    }
+	initiateHeartbeat(heartbeatInterval: number) {
+		this.sendFrame({type: "HBT", heartbeatInterval});
+	}
 
-    get isOpen() {
-        return this.webSocket.readyState == 1; // 1...OPEN
-    }
-
-    initiateHeartbeat(heartbeatInterval: number) {
-        this.sendFrame({type: "HBT", heartbeatInterval});
-    }
-
-    private handleAck(frameId: string, payload: string | undefined) {
-        const promise = this.callbacks.get(frameId);
-        if (promise) {
+	private handleAck(frameId: string, payload: string | undefined) {
+		const promise = this.takePendingMessage(frameId);
+		if (promise) {
 			const result = payload ? JSON.parse(payload) : undefined;
-            promise.resolve(result);
-        }
-    }
+			promise.resolve(result);
+		}
+	}
 
-    private handleNak(frameId: string, payload: string | undefined) {
-        const promise = this.callbacks.get(frameId);
-        if (promise) {
+	private handleNak(frameId: string, payload: string | undefined) {
+		const promise = this.takePendingMessage(frameId);
+		if (promise) {
 			const error = payload ? createVcmpError(JSON.parse(payload)) : new VcmpError({
 				title: "Message handling failed",
 				status: 500,
-				detail: "Unspecified error in message handling."
+				detail: "Unspecified error in message handling.",
 			});
-            promise.reject(error);
-        }
-    }
+			promise.reject(error);
+		}
+	}
 
-    private sendFrame(frame: VcmpFrame) {
-        if (this.webSocket) {
+	/**
+	 * Removes and returns the promise callbacks of a pending message, clearing its ack timeout.
+	 * Returns undefined if the message is not pending (already settled or unknown).
+	 */
+	private takePendingMessage(frameId: string) {
+		const promise = this.callbacks.get(frameId);
+		if (promise) {
+			this.callbacks.delete(frameId);
+			if (promise.timeout) {
+				clearTimeout(promise.timeout as any);
+			}
+		}
+		return promise;
+	}
+
+	private failPendingMessage(frameId: string, error: VcmpError) {
+		const promise = this.takePendingMessage(frameId);
+		if (promise) {
+			this.debug?.warn("Failing pending message", frameId, error.detail);
+			promise.reject(error);
+		}
+	}
+
+	private failAllPendingMessages(error: VcmpError) {
+		for (const frameId of [...this.callbacks.keys()]) {
+			this.failPendingMessage(frameId, error);
+		}
+	}
+
+	private sendFrame(frame: VcmpFrame) {
+		if (this.webSocket) {
 			const serializedFrame = serializeVcmpFrame(frame);
 			this.debug?.debug("Sending frame", serializedFrame);
 			this.webSocket.send(serializedFrame);
-        }
-    }
+		}
+	}
 
-    private handleOpen = () => {
-        this.debug?.debug("WebSocket session open");
-        this.awaitingHeartbeat = true;
-        this.onOpen && this.onOpen();
-    };
+	private handleOpen = () => {
+		this.debug?.debug("WebSocket session open");
+		this.awaitingHeartbeat = true;
+		this.onOpen && this.onOpen();
+	};
 
-    private handleClose = (event: CloseEvent | NodeWebSocket.CloseEvent) => {
-        this.debug?.debug("WebSocket session closed", {
-            type: event.type,
-            code: event.code,
-            reason: event.reason
-        });
-        if (this.heartbeatTimeout) {
-            clearTimeout(this.heartbeatTimeout as any);
-        }
-        if (this.heartbeatReceiveTimeout) {
-            clearTimeout(this.heartbeatReceiveTimeout as any);
-        }
-        this.onClose && this.onClose();
-    };
+	private handleClose = (event: CloseEvent | NodeWebSocket.CloseEvent) => {
+		this.debug?.debug("WebSocket session closed", {
+			type: event.type,
+			code: event.code,
+			reason: event.reason,
+		});
+		if (this.heartbeatTimeout) {
+			clearTimeout(this.heartbeatTimeout as any);
+		}
+		if (this.heartbeatReceiveTimeout) {
+			clearTimeout(this.heartbeatReceiveTimeout as any);
+		}
+		this.failAllPendingMessages(
+			new VcmpError({
+				title: "Session closed",
+				status: 503,
+				detail: "The session was closed before the message was acknowledged.",
+			}),
+		);
+		this.onClose && this.onClose();
+	};
 
-    private handleError = () => {
-        this.debug?.warn("WebSocket session error");
-        if (this.webSocket) {
-            this.webSocket.close();
-        }
-    };
+	private handleError = () => {
+		this.debug?.warn("WebSocket session error");
+		if (this.webSocket) {
+			this.webSocket.close();
+		}
+	};
 
-    private handleMessage = (event: MessageEvent | NodeWebSocket.MessageEvent) => {
-        if (typeof event.data == "string") {
+	private handleMessage = (event: MessageEvent | NodeWebSocket.MessageEvent) => {
+		if (typeof event.data == "string") {
 			this.debug?.debug("Received frame", event.data);
-            const frame = parseVcmpFrame(event.data);
+			const frame = parseVcmpFrame(event.data);
 			this.debug?.debug("Parsed frame", frame);
-            switch (frame.type) {
-                case "HBT":
-                    this.handleHeartbeatReceived(frame);
-                    break;
+			switch (frame.type) {
+				case "HBT":
+					this.handleHeartbeatReceived(frame);
+					break;
 
-                case "ACK":
-                    this.handleAck(frame.id, frame.payload);
-                    break;
+				case "ACK":
+					this.handleAck(frame.id, frame.payload);
+					break;
 
-                case "NAK":
-                    this.handleNak(frame.id, frame.payload);
-                    break;
+				case "NAK":
+					this.handleNak(frame.id, frame.payload);
+					break;
 
-                case "MSG":
-                    this.handleVcmpMessage(frame.id, frame.payload);
-                    break;
-            }
-        }
-    };
+				case "MSG":
+					this.handleVcmpMessage(frame.id, frame.payload);
+					break;
+			}
+		}
+	};
 
-    private handleHeartbeatReceived(frame: VcmpHeartbeatFrame) {
-        // check whether we are currently awaiting a heartbeat
-        if (this.awaitingHeartbeat) {
-            // clear the flag that we are awaiting a heartbeat
-            this.awaitingHeartbeat = false;
+	private handleHeartbeatReceived(frame: VcmpHeartbeatFrame) {
+		// check whether we are currently awaiting a heartbeat
+		if (this.awaitingHeartbeat) {
+			// clear the flag that we are awaiting a heartbeat
+			this.awaitingHeartbeat = false;
 
-            this.debug?.debug("Received heartbeat.");
+			this.debug?.debug("Received heartbeat.");
 
-            // clear previous heartbeat receive timeout
-            clearTimeout(this.heartbeatReceiveTimeout as any);
+			// clear previous heartbeat receive timeout
+			clearTimeout(this.heartbeatReceiveTimeout as any);
 
-            // send heartbeat after the interval passes
-            this.heartbeatTimeout = setTimeout(() => {
-                this.debug?.debug("Sending heartbeat.");
+			// send heartbeat after the interval passes
+			this.heartbeatTimeout = setTimeout(() => {
+				this.debug?.debug("Sending heartbeat.");
 
-                // send the heartbeat
-                this.sendFrame(frame);
+				// send the heartbeat
+				this.sendFrame(frame);
 
-                // set the flag that we await a heartbeat
-                this.awaitingHeartbeat = true;
+				// set the flag that we await a heartbeat
+				this.awaitingHeartbeat = true;
 
-                // set up a new heartbeat receive timeout, that closes the session
-                // if we don't receive a heartbeat back within 2 x interval
-                this.heartbeatReceiveTimeout = setTimeout(() => {
-                    this.debug?.warn("Did not receive heartbeat in time. Closing session.");
-                    this.close();
-                }, 2 * frame.heartbeatInterval);
-            }, frame.heartbeatInterval);
-        }
-        else {
-            this.debug?.warn("Ignoring unexpected heartbeat.");
-        }
-    }
+				// set up a new heartbeat receive timeout, that closes the session
+				// if we don't receive a heartbeat back within 2 x interval
+				this.heartbeatReceiveTimeout = setTimeout(() => {
+					this.debug?.warn("Did not receive heartbeat in time. Closing session.");
+					this.close();
+				}, 2 * frame.heartbeatInterval);
+			}, frame.heartbeatInterval);
+		}
+		else {
+			this.debug?.warn("Ignoring unexpected heartbeat.");
+		}
+	}
 
-    private handleVcmpMessage(frameId: string, payload: string | undefined) {
-        const message = payload ? JSON.parse(payload) : {} as any;
-        const type = message["@type"];
-        if (type) {
-            const handler = this.resolver(type);
-            if (handler) {
-                asyncExecute(async () => {
-                    try {
-                        const result = await handler(message, this);
-                        this.sendFrame({type: "ACK", id: frameId, payload: result ? JSON.stringify(result) : undefined});
-                    }
-                    catch (error) {
-                        this.debug?.warn("Error in handler, sending NAK", error);
-                        this.sendFrame({type: "NAK", id: frameId, payload: JSON.stringify(createVcmpError(error))});
-                    }
-                });
-            }
-            else {
-                this.debug?.warn("No handler found for message, sending NAK", message);
-                this.sendFrame({type: "NAK", id: frameId});
-            }
-        }
-        else {
-            this.debug?.error("Could not determine type of message", message);
-        }
-    }
-
+	private handleVcmpMessage(frameId: string, payload: string | undefined) {
+		const message = payload ? JSON.parse(payload) : {} as any;
+		const type = message["@type"];
+		if (type) {
+			const handler = this.resolver(type);
+			if (handler) {
+				asyncExecute(async () => {
+					try {
+						const result = await handler(message, this);
+						this.sendFrame({
+							type: "ACK",
+							id: frameId,
+							payload: result ? JSON.stringify(result) : undefined,
+						});
+					}
+					catch (error) {
+						this.debug?.warn("Error in handler, sending NAK", error);
+						this.sendFrame({type: "NAK", id: frameId, payload: JSON.stringify(createVcmpError(error))});
+					}
+				});
+			}
+			else {
+				this.debug?.warn("No handler found for message, sending NAK", message);
+				this.sendFrame({type: "NAK", id: frameId});
+			}
+		}
+		else {
+			this.debug?.error("Could not determine type of message", message);
+		}
+	}
 }

--- a/packages/vcmp/src/session.ts
+++ b/packages/vcmp/src/session.ts
@@ -7,24 +7,16 @@ import {CloseHandler, ConsoleLike, OpenHandler, VcmpHandler, VcmpMessage} from "
 type PromiseCallbacks = {
 	resolve: (result?: any) => void;
 	reject: (reason?: any) => void;
-	timeout?: number | NodeJS.Timeout;
 };
 
 interface VcmpSessionOptions {
 	webSocket: WebSocket | NodeWebSocket;
 	resolver: (type: string) => VcmpHandler<any> | undefined;
 	debug?: ConsoleLike;
-	/**
-	 * Optional timeout in milliseconds for awaiting the acknowledgement of a sent message.
-	 * When it elapses, the promise returned from `send` rejects with a `VcmpError` (status 504).
-	 * Disabled by default (or with a value of 0 or below): the promise then settles only on
-	 * ACK/NAK or when the session closes — bounding the wait is the caller's decision.
-	 */
-	ackTimeout?: number;
 }
 
 export class VcmpSession {
-	constructor({webSocket, resolver, debug, ackTimeout}: VcmpSessionOptions) {
+	constructor({webSocket, resolver, debug}: VcmpSessionOptions) {
 		webSocket.onmessage = this.handleMessage;
 		webSocket.onerror = this.handleError;
 		webSocket.onopen = this.handleOpen;
@@ -33,13 +25,11 @@ export class VcmpSession {
 		this.webSocket = webSocket;
 		this.resolver = resolver;
 		this.debug = debug;
-		this.ackTimeout = ackTimeout ?? 0;
 	}
 
 	private readonly webSocket: WebSocket | NodeWebSocket;
 	private readonly resolver: (type: string) => VcmpHandler<any> | undefined;
 	private readonly debug?: ConsoleLike;
-	private readonly ackTimeout: number;
 
 	public onOpen?: OpenHandler;
 	public onClose?: CloseHandler;
@@ -65,22 +55,16 @@ export class VcmpSession {
 			}
 			const payload = JSON.stringify(message);
 			const id = generateVcmpFrameId();
-			// Send before registering the callbacks entry: if sendFrame throws synchronously,
-			// the executor rejects the promise and no entry or timer is left behind. The ACK
-			// cannot overtake the registration, since it arrives on a later event-loop turn.
-			this.sendFrame({type: "MSG", id, payload});
-			const timeout = this.ackTimeout > 0
-				? setTimeout(() =>
-					this.failPendingMessage(
-						id,
-						new VcmpError({
-							title: "Acknowledgement timeout",
-							status: 504,
-							detail: `The message was not acknowledged within ${this.ackTimeout} ms.`,
-						}),
-					), this.ackTimeout)
-				: undefined;
-			this.callbacks.set(id, {resolve, reject, timeout});
+			// Register before sending: a synchronously-delivering WebSocket (in-memory pairs,
+			// test doubles passed via customWebSocket) can deliver the ACK during sendFrame.
+			this.callbacks.set(id, {resolve, reject});
+			try {
+				this.sendFrame({type: "MSG", id, payload});
+			}
+			catch (error) {
+				this.callbacks.delete(id);
+				throw error;
+			}
 		});
 	}
 
@@ -93,7 +77,7 @@ export class VcmpSession {
 	}
 
 	initiateHeartbeat(heartbeatInterval: number) {
-		this.sendFrame({type: "HBT", heartbeatInterval});
+		this.sendHeartbeat({type: "HBT", heartbeatInterval});
 	}
 
 	private handleAck(frameId: string, payload: string | undefined) {
@@ -104,11 +88,13 @@ export class VcmpSession {
 				promise.resolve(result);
 			}
 			catch (error) {
+				this.debug?.warn("Could not parse ACK payload", payload, error);
 				promise.reject(
 					new VcmpError({
 						title: "Invalid acknowledgement",
 						status: 500,
 						detail: "The ACK payload could not be parsed.",
+						cause: error,
 					}),
 				);
 			}
@@ -127,10 +113,12 @@ export class VcmpSession {
 				});
 			}
 			catch (parseError) {
+				this.debug?.warn("Could not parse NAK payload", payload, parseError);
 				error = new VcmpError({
 					title: "Message handling failed",
 					status: 500,
 					detail: "The NAK payload could not be parsed.",
+					cause: parseError,
 				});
 			}
 			promise.reject(error);
@@ -138,16 +126,13 @@ export class VcmpSession {
 	}
 
 	/**
-	 * Removes and returns the promise callbacks of a pending message, clearing its ack timeout.
+	 * Removes and returns the promise callbacks of a pending message.
 	 * Returns undefined if the message is not pending (already settled or unknown).
 	 */
 	private takePendingMessage(frameId: string) {
 		const promise = this.callbacks.get(frameId);
 		if (promise) {
 			this.callbacks.delete(frameId);
-			if (promise.timeout) {
-				clearTimeout(promise.timeout as any);
-			}
 		}
 		return promise;
 	}
@@ -171,6 +156,19 @@ export class VcmpSession {
 			const serializedFrame = serializeVcmpFrame(frame);
 			this.debug?.debug("Sending frame", serializedFrame);
 			this.webSocket.send(serializedFrame);
+		}
+	}
+
+	/**
+	 * Sends a frame on a best-effort basis from the inbound message path,
+	 * where a send failure must not propagate into the WebSocket's message event.
+	 */
+	private trySendFrame(frame: VcmpFrame) {
+		try {
+			this.sendFrame(frame);
+		}
+		catch (error) {
+			this.debug?.warn("Could not send frame", frame.type, error);
 		}
 	}
 
@@ -212,7 +210,16 @@ export class VcmpSession {
 	private handleMessage = (event: MessageEvent | NodeWebSocket.MessageEvent) => {
 		if (typeof event.data == "string") {
 			this.debug?.debug("Received frame", event.data);
-			const frame = parseVcmpFrame(event.data);
+			let frame: ReturnType<typeof parseVcmpFrame>;
+			try {
+				frame = parseVcmpFrame(event.data);
+			}
+			catch (error) {
+				// A throw from the message event would be an uncaught exception under Node's
+				// `ws` and could take the whole process down. Log and drop the frame instead.
+				this.debug?.warn("Ignoring invalid frame", event.data, error);
+				return;
+			}
 			this.debug?.debug("Parsed frame", frame);
 			switch (frame.type) {
 				case "HBT":
@@ -234,6 +241,24 @@ export class VcmpSession {
 		}
 	};
 
+	private sendHeartbeat(frame: VcmpHeartbeatFrame) {
+		this.debug?.debug("Sending heartbeat.");
+
+		// set the flag that we await a heartbeat
+		this.awaitingHeartbeat = true;
+
+		// Arm the watchdog before sending: if the peer never sends a heartbeat back
+		// within 2 x interval, the connection is considered dead and closed. This also
+		// covers a peer that connects but never answers the initial heartbeat at all.
+		clearTimeout(this.heartbeatReceiveTimeout as any);
+		this.heartbeatReceiveTimeout = setTimeout(() => {
+			this.debug?.warn("Did not receive heartbeat in time. Closing session.");
+			this.close();
+		}, 2 * frame.heartbeatInterval);
+
+		this.trySendFrame(frame);
+	}
+
 	private handleHeartbeatReceived(frame: VcmpHeartbeatFrame) {
 		// check whether we are currently awaiting a heartbeat
 		if (this.awaitingHeartbeat) {
@@ -242,26 +267,11 @@ export class VcmpSession {
 
 			this.debug?.debug("Received heartbeat.");
 
-			// clear previous heartbeat receive timeout
+			// clear the heartbeat receive timeout
 			clearTimeout(this.heartbeatReceiveTimeout as any);
 
 			// send heartbeat after the interval passes
-			this.heartbeatTimeout = setTimeout(() => {
-				this.debug?.debug("Sending heartbeat.");
-
-				// send the heartbeat
-				this.sendFrame(frame);
-
-				// set the flag that we await a heartbeat
-				this.awaitingHeartbeat = true;
-
-				// set up a new heartbeat receive timeout, that closes the session
-				// if we don't receive a heartbeat back within 2 x interval
-				this.heartbeatReceiveTimeout = setTimeout(() => {
-					this.debug?.warn("Did not receive heartbeat in time. Closing session.");
-					this.close();
-				}, 2 * frame.heartbeatInterval);
-			}, frame.heartbeatInterval);
+			this.heartbeatTimeout = setTimeout(() => this.sendHeartbeat(frame), frame.heartbeatInterval);
 		}
 		else {
 			this.debug?.warn("Ignoring unexpected heartbeat.");
@@ -269,7 +279,26 @@ export class VcmpSession {
 	}
 
 	private handleVcmpMessage(frameId: string, payload: string | undefined) {
-		const message = payload ? JSON.parse(payload) : {} as any;
+		let message: any;
+		try {
+			message = payload ? JSON.parse(payload) : {};
+		}
+		catch (error) {
+			// NAK the frame so the peer's send() settles instead of pending forever.
+			this.debug?.warn("Could not parse message payload, sending NAK", payload, error);
+			this.trySendFrame({
+				type: "NAK",
+				id: frameId,
+				payload: JSON.stringify(
+					new VcmpError({
+						title: "Invalid message",
+						status: 400,
+						detail: "The message payload could not be parsed.",
+					}),
+				),
+			});
+			return;
+		}
 		const type = message["@type"];
 		if (type) {
 			const handler = this.resolver(type);
@@ -277,7 +306,7 @@ export class VcmpSession {
 				asyncExecute(async () => {
 					try {
 						const result = await handler(message, this);
-						this.sendFrame({
+						this.trySendFrame({
 							type: "ACK",
 							id: frameId,
 							payload: result !== undefined ? JSON.stringify(result) : undefined,
@@ -285,17 +314,32 @@ export class VcmpSession {
 					}
 					catch (error) {
 						this.debug?.warn("Error in handler, sending NAK", error);
-						this.sendFrame({type: "NAK", id: frameId, payload: JSON.stringify(createVcmpError(error))});
+						this.trySendFrame({
+							type: "NAK",
+							id: frameId,
+							payload: JSON.stringify(createVcmpError(error)),
+						});
 					}
 				});
 			}
 			else {
 				this.debug?.warn("No handler found for message, sending NAK", message);
-				this.sendFrame({type: "NAK", id: frameId});
+				this.trySendFrame({type: "NAK", id: frameId});
 			}
 		}
 		else {
-			this.debug?.error("Could not determine type of message", message);
+			this.debug?.error("Could not determine type of message, sending NAK", message);
+			this.trySendFrame({
+				type: "NAK",
+				id: frameId,
+				payload: JSON.stringify(
+					new VcmpError({
+						title: "Invalid message",
+						status: 400,
+						detail: "The message does not specify a type.",
+					}),
+				),
+			});
 		}
 	}
 }

--- a/packages/vcmp/tests/client.ts
+++ b/packages/vcmp/tests/client.ts
@@ -6,6 +6,36 @@ interface SampleMessage {
 	"@type": "SampleType";
 }
 
+/** A controllable fake socket whose close event is delivered explicitly, like a real socket's. */
+class ControlledWebSocket {
+	static instances: ControlledWebSocket[] = [];
+	readyState = 0; // CONNECTING
+	onopen?: () => void;
+	onclose?: (event: any) => void;
+	onmessage?: (event: any) => void;
+	onerror?: () => void;
+
+	constructor(url: string) {
+		ControlledWebSocket.instances.push(this);
+	}
+
+	send(data: string) {}
+
+	close() {
+		this.readyState = 3; // CLOSED; the close event arrives separately via fireClose()
+	}
+
+	open() {
+		this.readyState = 1; // OPEN
+		this.onopen?.();
+	}
+
+	fireClose() {
+		this.readyState = 3;
+		this.onclose?.({type: "close", code: 1006, reason: ""});
+	}
+}
+
 describe("VcmpClient", () => {
 	it("can instantiate client and start/stop", () => {
 		const client = new VcmpClient("ws://localhost:22", {
@@ -39,6 +69,29 @@ describe("VcmpClient", () => {
 		new VcmpClient("ws://localhost:22", {
 			debug: console,
 		});
+	});
+
+	it("keeps the new session when the old socket's close event arrives after a restart", async () => {
+		ControlledWebSocket.instances = [];
+		const client = new VcmpClient("ws://test", {
+			customWebSocket: ControlledWebSocket as any,
+			reconnectTimeout: 20,
+		});
+		client.start();
+		const first = ControlledWebSocket.instances[0];
+		first.open();
+		client.stop();
+		client.start();
+		const second = ControlledWebSocket.instances[1];
+		second.open();
+		expect(client.connected).to.be.true;
+		// the first socket's close event arrives only now (it is asynchronous in real life)
+		// and must neither discard the new session nor schedule a reconnect
+		first.fireClose();
+		expect(client.connected).to.be.true;
+		await new Promise<void>(resolve => setTimeout(resolve, 60));
+		expect(ControlledWebSocket.instances).to.have.length(2);
+		client.stop();
 	});
 
 	it("writes to debug object", async () => {

--- a/packages/vcmp/tests/client.ts
+++ b/packages/vcmp/tests/client.ts
@@ -94,6 +94,21 @@ describe("VcmpClient", () => {
 		client.stop();
 	});
 
+	it("closes the session when the server never initiates a heartbeat", async () => {
+		ControlledWebSocket.instances = [];
+		const client = new VcmpClient("ws://test", {
+			customWebSocket: ControlledWebSocket as any,
+			initialHeartbeatTimeout: 20,
+		});
+		client.start();
+		const socket = ControlledWebSocket.instances[0];
+		socket.open();
+		expect(client.connected).to.be.true;
+		await new Promise<void>(resolve => setTimeout(resolve, 80));
+		expect(client.connected).to.be.false;
+		client.stop();
+	});
+
 	it("cancels a pending reconnect when start() is called", async () => {
 		ControlledWebSocket.instances = [];
 		const client = new VcmpClient("ws://test", {

--- a/packages/vcmp/tests/client.ts
+++ b/packages/vcmp/tests/client.ts
@@ -94,6 +94,29 @@ describe("VcmpClient", () => {
 		client.stop();
 	});
 
+	it("cancels a pending reconnect when start() is called", async () => {
+		ControlledWebSocket.instances = [];
+		const client = new VcmpClient("ws://test", {
+			customWebSocket: ControlledWebSocket as any,
+			reconnectTimeout: 30,
+		});
+		client.start();
+		const first = ControlledWebSocket.instances[0];
+		first.open();
+		// the connection drops: a reconnect is scheduled...
+		first.fireClose();
+		// ...but the app reconnects right away instead of waiting for the timer
+		client.start();
+		const second = ControlledWebSocket.instances[1];
+		second.open();
+		expect(client.connected).to.be.true;
+		// the previously scheduled reconnect must not open a third, duplicate connection
+		await new Promise<void>(resolve => setTimeout(resolve, 100));
+		expect(ControlledWebSocket.instances).to.have.length(2);
+		expect(client.connected).to.be.true;
+		client.stop();
+	});
+
 	it("writes to debug object", async () => {
 		let messageCount = 0;
 		const incMessageCount = () => messageCount++;

--- a/packages/vcmp/tests/session.ts
+++ b/packages/vcmp/tests/session.ts
@@ -1,0 +1,180 @@
+import {VcmpError, VcmpSession} from "@variocube/vcmp";
+import {expect} from "chai";
+
+class FakeWebSocket {
+	readyState = 1; // OPEN
+	sent: string[] = [];
+	onopen?: () => void;
+	onclose?: (event: any) => void;
+	onmessage?: (event: any) => void;
+	onerror?: () => void;
+
+	send(data: string) {
+		this.sent.push(data);
+	}
+
+	close() {
+		this.readyState = 3; // CLOSED
+		this.onclose?.({type: "close", code: 1000, reason: ""});
+	}
+
+	receive(data: string) {
+		this.onmessage?.({data});
+	}
+}
+
+/** Delivers the ACK synchronously from within send(), like an in-memory loopback socket. */
+class SyncAckWebSocket extends FakeWebSocket {
+	send(data: string) {
+		super.send(data);
+		if (data.startsWith("MSG")) {
+			this.receive(`ACK${data.slice(3, 15)}"pong"`);
+		}
+	}
+}
+
+function createSession(webSocket: FakeWebSocket, resolver: (type: string) => any = () => undefined) {
+	return new VcmpSession({webSocket: webSocket as any, resolver});
+}
+
+function sentFrameId(rawFrame: string) {
+	return rawFrame.slice(3, 15);
+}
+
+function sleep(timeoutMs: number) {
+	return new Promise<void>(resolve => setTimeout(resolve, timeoutMs));
+}
+
+describe("VcmpSession", () => {
+	it("rejects pending sends when the session closes", async () => {
+		const webSocket = new FakeWebSocket();
+		const session = createSession(webSocket);
+		const pending = session.send({"@type": "foo"});
+		webSocket.close();
+		try {
+			await pending;
+			expect.fail("Expected error");
+		}
+		catch (error) {
+			if (!(error instanceof VcmpError)) throw new Error("Expected error to be instance of VcmpError");
+			expect(error.status).to.be.equal(503);
+			expect(error.title).to.be.equal("Session closed");
+		}
+	});
+
+	it("rejects sends when the socket is not open", async () => {
+		const webSocket = new FakeWebSocket();
+		webSocket.readyState = 0; // CONNECTING
+		const session = createSession(webSocket);
+		try {
+			await session.send({"@type": "foo"});
+			expect.fail("Expected error");
+		}
+		catch (error) {
+			if (!(error instanceof VcmpError)) throw new Error("Expected error to be instance of VcmpError");
+			expect(error.status).to.be.equal(503);
+			expect(error.title).to.be.equal("Session not open");
+		}
+	});
+
+	it("resolves a send whose ACK is delivered synchronously during send", async () => {
+		const webSocket = new SyncAckWebSocket();
+		const session = createSession(webSocket);
+		const result = await session.send({"@type": "foo"});
+		expect(result).to.be.equal("pong");
+	});
+
+	it("rejects with the thrown error when the socket's send throws synchronously", async () => {
+		const webSocket = new FakeWebSocket();
+		webSocket.send = () => {
+			throw new Error("boom");
+		};
+		const session = createSession(webSocket);
+		try {
+			await session.send({"@type": "foo"});
+			expect.fail("Expected error");
+		}
+		catch (error) {
+			expect((error as Error).message).to.be.equal("boom");
+		}
+	});
+
+	it("rejects a send whose ACK payload cannot be parsed", async () => {
+		const webSocket = new FakeWebSocket();
+		const session = createSession(webSocket);
+		const pending = session.send({"@type": "foo"});
+		webSocket.receive(`ACK${sentFrameId(webSocket.sent[0])}{oops`);
+		try {
+			await pending;
+			expect.fail("Expected error");
+		}
+		catch (error) {
+			if (!(error instanceof VcmpError)) throw new Error("Expected error to be instance of VcmpError");
+			expect(error.status).to.be.equal(500);
+			expect(error.title).to.be.equal("Invalid acknowledgement");
+			expect(error.cause).to.be.instanceOf(SyntaxError);
+		}
+	});
+
+	it("NAKs an inbound message with an unparseable payload", () => {
+		const webSocket = new FakeWebSocket();
+		createSession(webSocket);
+		webSocket.receive("MSGabcdefghijkl{oops");
+		expect(webSocket.sent).to.have.length(1);
+		const nak = webSocket.sent[0];
+		expect(nak.slice(0, 3)).to.be.equal("NAK");
+		expect(sentFrameId(nak)).to.be.equal("abcdefghijkl");
+		expect(JSON.parse(nak.slice(15)).status).to.be.equal(400);
+	});
+
+	it("NAKs an inbound message without a type", () => {
+		const webSocket = new FakeWebSocket();
+		createSession(webSocket);
+		webSocket.receive(`MSGabcdefghijkl{"foo":"bar"}`);
+		expect(webSocket.sent).to.have.length(1);
+		const nak = webSocket.sent[0];
+		expect(nak.slice(0, 3)).to.be.equal("NAK");
+		expect(JSON.parse(nak.slice(15)).status).to.be.equal(400);
+	});
+
+	it("ignores an invalid frame without throwing", () => {
+		const webSocket = new FakeWebSocket();
+		createSession(webSocket);
+		webSocket.receive("XXXsomething");
+		expect(webSocket.sent).to.have.length(0);
+		expect(webSocket.readyState).to.be.equal(1);
+	});
+
+	it("closes the session when the initiated heartbeat is never answered", async () => {
+		const webSocket = new FakeWebSocket();
+		const session = createSession(webSocket);
+		const pending = session.send({"@type": "foo"});
+		session.initiateHeartbeat(10);
+		// the watchdog (2 x interval) must close the session even though no heartbeat
+		// was ever received
+		await sleep(50);
+		expect(webSocket.readyState).to.be.equal(3);
+		try {
+			await pending;
+			expect.fail("Expected error");
+		}
+		catch (error) {
+			if (!(error instanceof VcmpError)) throw new Error("Expected error to be instance of VcmpError");
+			expect(error.status).to.be.equal(503);
+			expect(error.title).to.be.equal("Session closed");
+		}
+	});
+
+	it("keeps the session open while heartbeats are answered", async () => {
+		const webSocket = new FakeWebSocket();
+		const session = createSession(webSocket);
+		session.initiateHeartbeat(100);
+		webSocket.receive("HBT100");
+		await sleep(150);
+		// after the interval, the next heartbeat went out and its watchdog (200 ms) is
+		// still pending — the session must not have been closed
+		expect(webSocket.sent.filter(frame => frame.startsWith("HBT"))).to.have.length(2);
+		expect(webSocket.readyState).to.be.equal(1);
+		session.close();
+	});
+});

--- a/packages/vcmp/tests/session.ts
+++ b/packages/vcmp/tests/session.ts
@@ -45,6 +45,16 @@ function sleep(timeoutMs: number) {
 	return new Promise<void>(resolve => setTimeout(resolve, timeoutMs));
 }
 
+async function waitFor(condition: () => boolean, timeoutMs = 2000) {
+	const start = Date.now();
+	while (!condition()) {
+		if (Date.now() - start > timeoutMs) {
+			throw new Error("Timed out waiting for condition");
+		}
+		await sleep(5);
+	}
+}
+
 describe("VcmpSession", () => {
 	it("rejects pending sends when the session closes", async () => {
 		const webSocket = new FakeWebSocket();
@@ -84,7 +94,7 @@ describe("VcmpSession", () => {
 		expect(result).to.be.equal("pong");
 	});
 
-	it("rejects with the thrown error when the socket's send throws synchronously", async () => {
+	it("rejects with a VcmpError when the socket's send throws synchronously", async () => {
 		const webSocket = new FakeWebSocket();
 		webSocket.send = () => {
 			throw new Error("boom");
@@ -95,7 +105,10 @@ describe("VcmpSession", () => {
 			expect.fail("Expected error");
 		}
 		catch (error) {
-			expect((error as Error).message).to.be.equal("boom");
+			if (!(error instanceof VcmpError)) throw new Error("Expected error to be instance of VcmpError");
+			expect(error.status).to.be.equal(503);
+			expect(error.title).to.be.equal("Send failed");
+			expect((error.cause as Error).message).to.be.equal("boom");
 		}
 	});
 
@@ -170,11 +183,35 @@ describe("VcmpSession", () => {
 		const session = createSession(webSocket);
 		session.initiateHeartbeat(100);
 		webSocket.receive("HBT100");
-		await sleep(150);
-		// after the interval, the next heartbeat went out and its watchdog (200 ms) is
-		// still pending — the session must not have been closed
-		expect(webSocket.sent.filter(frame => frame.startsWith("HBT"))).to.have.length(2);
+		// after the interval, the next heartbeat goes out; its own watchdog (200 ms from
+		// the send we are polling for) is still pending — the session must still be open
+		await waitFor(() => webSocket.sent.filter(frame => frame.startsWith("HBT")).length >= 2);
 		expect(webSocket.readyState).to.be.equal(1);
 		session.close();
+	});
+
+	it("does not arm the watchdog when the heartbeat cannot be sent", async () => {
+		const webSocket = new FakeWebSocket();
+		webSocket.readyState = 0; // CONNECTING
+		const session = createSession(webSocket);
+		session.initiateHeartbeat(10);
+		await sleep(50);
+		// no heartbeat was sent, and no watchdog closed the (healthy) connection
+		expect(webSocket.sent).to.have.length(0);
+		expect(webSocket.readyState).to.be.equal(0);
+	});
+
+	it("NAKs with a fallback when the handler error cannot be serialized", async () => {
+		const webSocket = new FakeWebSocket();
+		const circular: any = {title: "foo", status: 400};
+		circular.self = circular;
+		createSession(webSocket, () => () => {
+			throw circular;
+		});
+		webSocket.receive(`MSGabcdefghijkl{"@type":"foo"}`);
+		await waitFor(() => webSocket.sent.length === 1);
+		const nak = webSocket.sent[0];
+		expect(nak.slice(0, 3)).to.be.equal("NAK");
+		expect(JSON.parse(nak.slice(15)).status).to.be.equal(500);
 	});
 });

--- a/packages/vcmp/tests/session.ts
+++ b/packages/vcmp/tests/session.ts
@@ -190,15 +190,50 @@ describe("VcmpSession", () => {
 		session.close();
 	});
 
-	it("does not arm the watchdog when the heartbeat cannot be sent", async () => {
+	it("defers an initiated heartbeat until the socket opens", async () => {
 		const webSocket = new FakeWebSocket();
 		webSocket.readyState = 0; // CONNECTING
 		const session = createSession(webSocket);
 		session.initiateHeartbeat(10);
 		await sleep(50);
-		// no heartbeat was sent, and no watchdog closed the (healthy) connection
+		// nothing is sent and no watchdog closes the (healthy) connection while the
+		// socket is still connecting
 		expect(webSocket.sent).to.have.length(0);
 		expect(webSocket.readyState).to.be.equal(0);
+		// once the socket opens, the heartbeat starts — and its watchdog closes the
+		// session when the peer never answers
+		webSocket.readyState = 1;
+		webSocket.onopen?.();
+		expect(webSocket.sent).to.deep.equal(["HBT10"]);
+		await waitFor(() => webSocket.readyState === 3);
+	});
+
+	it("ignores a heartbeat with an invalid interval", async () => {
+		const webSocket = new FakeWebSocket();
+		createSession(webSocket);
+		webSocket.receive("HBT");
+		webSocket.receive("HBTfoo");
+		await sleep(30);
+		// no HBTNaN echo, and no watchdog closed the session
+		expect(webSocket.sent).to.have.length(0);
+		expect(webSocket.readyState).to.be.equal(1);
+	});
+
+	it("closes the session when an expected heartbeat never arrives", async () => {
+		const webSocket = new FakeWebSocket();
+		const session = createSession(webSocket);
+		session.expectHeartbeat(10);
+		await waitFor(() => webSocket.readyState === 3);
+	});
+
+	it("keeps the session open when the expected heartbeat arrives", async () => {
+		const webSocket = new FakeWebSocket();
+		const session = createSession(webSocket);
+		session.expectHeartbeat(50);
+		webSocket.receive("HBT1000");
+		await sleep(100);
+		expect(webSocket.readyState).to.be.equal(1);
+		session.close();
 	});
 
 	it("NAKs with a fallback when the handler error cannot be serialized", async () => {


### PR DESCRIPTION
Fixes #31

## What

`VcmpSession.send()` promises could stay pending forever when the ACK never arrived — the root cause of `openCompartment()` hanging in the cube-app-sdk (lock opens, promise never resolves). This PR makes every `send()` settle once the session is gone:

- **Reject pending sends on session close** with `VcmpError` 503 ("Session closed"). Previously `handleClose` only cleared heartbeat timers; in-flight promises were orphaned.
- **Reject immediately when the socket is not open** with `VcmpError` 503 ("Session not open"). Previously the frame was written into a CONNECTING/CLOSING/CLOSED socket and silently discarded. `VcmpClient.send()` without a session also rejects a `VcmpError` 503 now (previously a plain `Error`).
- **No acknowledgement timeout.** An earlier revision added an `ackTimeout` option; it is **removed again**: VCMP does not bound how long a peer may take to acknowledge (the ACK only arrives after the peer's handler completes), so bounding the wait is handled explicitly on the caller side — race the individual send against your own timer where needed. Same policy decision as variocube/vcmp-spring#23.
- **Heartbeat watchdog armed on initiation.** The receive watchdog (2 × interval) is now armed when a heartbeat is successfully *sent*, not only once the first HBT has come back — so a peer that connects and never answers any heartbeat (half-open TCP, frozen UI, port probe) is detected and the session closed, which settles pending sends via the close path. This is what makes the no-timeout policy safe. Initiating on a still-CONNECTING socket defers the heartbeat until the socket opens instead of silently disabling it, and malformed HBT frames (NaN interval) are dropped instead of poisoning the cycle.
- **The client expects the server's heartbeat.** New `VcmpSession.expectHeartbeat(ms)`; `VcmpClient` arms it on session open via the new `initialHeartbeatTimeout` option (default 60 s, `<= 0` disables), closing a half-open connection through which no heartbeat ever arrives — the residual way a client-side send could still hang.
- **Robust inbound path**: an invalid frame is logged and dropped instead of throwing out of the WebSocket message event (which would be an uncaught exception under Node's `ws`); a MSG with an unparseable payload or missing `@type` is NAKed (400) so the peer's send settles.
- **Safe `stop()`/`start()` restart**: `start()` cancels a pending reconnect and discards an existing session, session events are dispatched per captured session, and a discarded session's events are detached — so a stale close event or a still-armed reconnect timer can no longer discard the live session, open a duplicate connection, or fire `onOpen`/`onClose` on an application that has moved on.
- **Fix callbacks-map leak**: settled messages are now removed from the map (previously entries lived as long as the session), and a synchronous send failure takes its entry back.
- **`broadcast()` handles per-session rejections** so a session closing mid-broadcast cannot crash the process with an unhandled rejection — and returns a never-rejecting promise with per-session `{session, result, error}` entries, so callers can observe NAKs; failures are logged via the (opt-in) debug sink.
- Defensive fixes surfaced in review: unparseable ACK/NAK payloads reject instead of stranding the promise (logging the payload and attaching the original error as `cause`), and falsy handler results (`0`, `false`, `""`) survive the ACK payload.

## Tests

Session-level suite `packages/vcmp/tests/session.ts` (14 tests): close-while-pending, send on a non-open socket, synchronously-delivered ACK, synchronous send failure, malformed ACK payload, malformed MSG payload, missing `@type`, invalid frame, unserializable handler error, heartbeat watchdog closing an unanswered session, deferred heartbeat start, invalid heartbeat interval, expected-heartbeat pair, and the heartbeat happy path. Client tests cover the stop/start restart race, the reconnect-timer race, and the initial-heartbeat expectation. Plus the server-side integration tests (close-before-ack, send-on-closed-session, broadcast results). Full suite: 37 + 9 tests passing on Node 24.

## Docs

`README.md` gains a "Send semantics" section documenting the settlement guarantees, the caller-side-timeout policy, the heartbeat prerequisite for the dead-connection backstop, and the retry caveat (a rejection ≠ the peer didn't process the message). The fire-and-forget example now attaches `.catch`.

## ⚠️ Breaking change

Sends that previously hung now reject, so **fire-and-forget `send()` call sites need a `.catch`** — otherwise a session closing at the wrong moment becomes an unhandled promise rejection, which terminates a Node process by default. Release this as a **major version bump**, and **gate the release on variocube/cube-app-sdk#47**, which attaches the missing `.catch`es to the known fire-and-forget call sites in `cube-app-service`. The SDK surfaces these as NAK/errors to apps, which is the intent — apps can retry instead of waiting forever. Companion server-side fix: variocube/vcmp-spring#23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
